### PR TITLE
Fix errors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ export BUSYBOX_VERSION=1.32.0
 #
 echo "[+] Checking / installing dependencies..."
 sudo apt-get -q update
-sudo apt-get -q install -y bison flex libelf-dev cpio build-essential libssl-dev qemu-system-x86
+sudo apt-get -q install -y bc bison flex libelf-dev cpio build-essential libssl-dev qemu-system-x86
 
 #
 # linux kernel

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,11 @@ echo "CONFIG_DEBUG_FS=y" >> linux-$KERNEL_VERSION/.config
 echo "CONFIG_DEBUG_INFO_DWARF4=y" >> linux-$KERNEL_VERSION/.config
 echo "CONFIG_DEBUG_INFO_BTF=y" >> linux-$KERNEL_VERSION/.config
 echo "CONFIG_FRAME_POINTER=y" >> linux-$KERNEL_VERSION/.config
+
+sed -i 'N;s/WARN("missing symbol table");\n\t\treturn -1;/\n\t\treturn 0;\n\t\t\/\/ A missing symbol table is actually possible if its an empty .o file.  This can happen for thunk_64.o./g' linux-$KERNEL_VERSION/tools/objtool/elf.c
+
+sed -i 's/unsigned long __force_order/\/\/ unsigned long __force_order/g' linux-$KERNEL_VERSION/arch/x86/boot/compressed/pgtable_64.c
+
 make -C linux-$KERNEL_VERSION -j16 bzImage
 
 #


### PR DESCRIPTION
Building `pwnkernel` on latest ubuntu(22.04), there's an error saying "arch/x86/entry/thunk_64.o: warning: objtool: missing symbol table". Tracking it down, it's regarding "binutils"  and has been mentioned/fixed before in this commit:
https://github.com/torvalds/linux/commit/1d489151e9f9d1647110277ff77282fe4d96d09b.patch
This is done by the first added line.

The second added line fixes another issue that I encountered,  #3 with multiple definition of `__force_order';`, just comments out one.
There are possibly still errors trying to build this on other distributions like kali, but this fix works for ubuntu latest.