### PR TITLE
[bugfix] copy_to/from_user for correct return value

### DIFF
--- a/src/hello_dev_char.c
+++ b/src/hello_dev_char.c
@@ -22,7 +22,7 @@ static int device_release(struct inode *inode, struct file *filp)
 static ssize_t device_read(struct file *filp, char *buffer, size_t length, loff_t *offset)
 {
 	char *msg = "Hello pwn.college!\n";
-	return strlen(msg) - copy_to_user(buffer, msg, strlen(msg));
+	return copy_to_user(buffer, msg, strlen(msg)) ? -EFAULT : 0;
 }
 
 static ssize_t device_write(struct file *filp, const char *buf, size_t len, loff_t *off)

--- a/src/hello_ioctl.c
+++ b/src/hello_ioctl.c
@@ -37,12 +37,19 @@ static ssize_t device_write(struct file *filp, const char *buf, size_t len, loff
 char message[16];
 static long device_ioctl(struct file *filp, unsigned int ioctl_num, unsigned long ioctl_param)
 {
-        printk(KERN_ALERT "Got ioctl argument %#x!", ioctl_num);
-        if (ioctl_num == PWN_GET && strcmp(message, "PASSWORD") == 0)
-        	printk(KERN_ALERT "Write %ld bytes to userspace!\n", copy_to_user((char *)ioctl_param, flag, 128));
-        else if (ioctl_num == PWN_SET)
-        	printk(KERN_ALERT "Read %ld bytes from userspace!\n", copy_from_user(message, (char *)ioctl_param, 16));
-        return 0;
+	int is_copy_invalid = 0;	
+	printk(KERN_ALERT "Got ioctl argument %#x!", ioctl_num);
+	if (ioctl_num == PWN_GET && strcmp(message, "PASSWORD") == 0) {
+		printk(KERN_ALERT "Writing to userspace!\n");
+		is_copy_invalid = copy_to_user((char *)ioctl_param, flag, 128);
+	} else if (ioctl_num == PWN_SET) {
+		printk(KERN_ALERT "Reading from userspace!\n");
+		is_copy_invalid = copy_from_user(message, (char *)ioctl_param, 16));
+	}
+
+	if (is_copy_invalid)
+		return -EFAULT;
+	return 0;
 }
 
 static struct file_operations fops = {

--- a/src/hello_proc_char.c
+++ b/src/hello_proc_char.c
@@ -21,7 +21,7 @@ static int device_release(struct inode *inode, struct file *filp)
 static ssize_t device_read(struct file *filp, char *buffer, size_t length, loff_t *offset)
 {
 	char *msg = "Hello pwn-college!\n";
-	return strlen(msg) - copy_to_user(buffer, msg, strlen(msg));
+	return copy_to_user(buffer, msg, strlen(msg)) ? -EFAULT : 0;
 }
 
 static ssize_t device_write(struct file *filp, const char *buf, size_t len, loff_t *off)


### PR DESCRIPTION
Hello!

I was using this repo for a quick ioctl template and realized that the semantics were incorrect for `copy_from_user` and `copy_to_user`.

In the original code the assumption is that these two functions return the number of bytes transferred. However, after taking a look at the man pages (https://www.unix.com/man-page/suse/9/copy_to_user, https://www.unix.com/man-page/centos/9/__copy_from_user) the actual return value is the number of bytes _not_ transferred to userspace. 

This really tripped me up on my research as I had just assumed it was number of bytes transferred and that 0 was a bad number to be having!

To fix this I rewrote the existing `copy_from_user` and `copy_to_user` function calls inside the `/src` directory to hopefully prevent any future misunderstanding.

Please let me know any comments or concerns.