### PR TITLE
Remove closing bracket at line 47 of hello_ioctl.c file in src folder

### DIFF
--- a/src/hello_ioctl.c
+++ b/src/hello_ioctl.c
@@ -44,7 +44,7 @@ static long device_ioctl(struct file *filp, unsigned int ioctl_num, unsigned lon
 		is_copy_invalid = copy_to_user((char *)ioctl_param, flag, 128);
 	} else if (ioctl_num == PWN_SET) {
 		printk(KERN_ALERT "Reading from userspace!\n");
-		is_copy_invalid = copy_from_user(message, (char *)ioctl_param, 16));
+		is_copy_invalid = copy_from_user(message, (char *)ioctl_param, 16);
 	}
 
 	if (is_copy_invalid)


### PR DESCRIPTION
Remove the closing bracket of the hello_ioctl.c to make the build process successful when running the build.sh script in the home directory.